### PR TITLE
[pentest] Add CryptoLib SCA and FI stub

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -97,6 +97,36 @@ FIRMWARE_DEPS_SCA = [
     "//sw/device/tests/penetrationtests/json:commands",
 ]
 
+FIRMWARE_DEPS_CRYPTOLIB = [
+    "//sw/device/tests/penetrationtests/firmware/sca:cryptolib_sca",
+    "//sw/device/tests/penetrationtests/firmware/sca:trigger_sca",
+    "//sw/device/tests/penetrationtests/firmware/fi:cryptolib_fi",
+    "//sw/device/tests/penetrationtests/firmware/lib:extclk_sca_fi",
+    "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+    "//sw/device/lib/base:csr",
+    "//sw/device/lib/base:status",
+    "//sw/device/lib/crypto/drivers:entropy",
+    "//sw/device/lib/testing/test_framework:check",
+    "//sw/device/lib/testing/test_framework:ottf_main",
+    "//sw/device/lib/testing/test_framework:ujson_ottf",
+    "//sw/device/lib/ujson",
+
+    # Include all JSON commands.
+    "//sw/device/tests/penetrationtests/json:commands",
+]
+
+opentitan_binary(
+    name = "firmware_cryptolib",
+    testonly = True,
+    srcs = [":firmware_cryptolib.c"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
+    ],
+    deps = FIRMWARE_DEPS_CRYPTOLIB,
+)
+
 opentitan_binary(
     name = "firmware_fi",
     testonly = True,
@@ -143,6 +173,20 @@ opentitan_binary(
         "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
     ],
     deps = FIRMWARE_DEPS_SCA,
+)
+
+opentitan_test(
+    name = "chip_pen_test_cryptolib",
+    srcs = [":firmware_cryptolib.c"],
+    exec_env = PENTEST_EXEC_ENVS,
+    fpga = fpga_params(tags = ["skip_in_ci"]),
+    silicon = silicon_params(
+        tags = [
+            "manual",
+            "skip_in_ci",
+        ],
+    ),
+    deps = FIRMWARE_DEPS_CRYPTOLIB,
 )
 
 opentitan_test(

--- a/sw/device/tests/penetrationtests/firmware/fi/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/fi/BUILD
@@ -29,6 +29,23 @@ cc_library(
 )
 
 cc_library(
+    name = "cryptolib_fi",
+    srcs = ["cryptolib_fi.c"],
+    hdrs = ["cryptolib_fi.h"],
+    deps = [
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+        "//sw/device/tests/penetrationtests/json:cryptolib_fi_commands",
+    ],
+)
+
+cc_library(
     name = "ibex_fi",
     srcs = [
         "ibex_fi.S",
@@ -38,6 +55,7 @@ cc_library(
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:flash_ctrl",
@@ -55,7 +73,6 @@ cc_library(
         "//sw/device/silicon_creator/manuf/lib:otp_fields",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
         "//sw/device/tests/penetrationtests/json:ibex_fi_commands",
-        "//sw/device/lib/base:hardened",
     ],
 )
 

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi.c
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h"
+#include "sw/device/tests/penetrationtests/json/cryptolib_fi_commands.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+status_t handle_cryptolib_fi_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_cpuctrl;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_cpuctrl));
+
+  pentest_select_trigger_type(kPentestTriggerTypeSw);
+  // As we are using the software defined trigger, the first argument of
+  // pentest_init is not needed. kPentestTriggerSourceAes is selected as a
+  // placeholder.
+  pentest_init(kPentestTriggerSourceAes,
+               kPentestPeripheralIoDiv4 | kPentestPeripheralEdn |
+                   kPentestPeripheralCsrng | kPentestPeripheralEntropy |
+                   kPentestPeripheralAes | kPentestPeripheralHmac |
+                   kPentestPeripheralKmac | kPentestPeripheralOtbn);
+
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+
+  // Read device ID and return to host.
+  TRY(pentest_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
+
+  return OK_STATUS();
+}
+
+status_t handle_cryptolib_fi(ujson_t *uj) {
+  cryptolib_fi_subcommand_t cmd;
+  TRY(ujson_deserialize_cryptolib_fi_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kCryptoLibFiSubcommandInit:
+      return handle_cryptolib_fi_init(uj);
+    default:
+      LOG_ERROR("Unrecognized CryptoLib FI subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_CRYPTOLIB_FI_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_CRYPTOLIB_FI_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+/**
+ * Initialize CryptoLib command handler.
+ *
+ * This command is designed to setup the CryptoLib FI firmware.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_cryptolib_fi_init(ujson_t *uj);
+
+/**
+ * CryptoLib FI command handler.
+ *
+ * Command handler for the CryptoLib FI command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_cryptolib_fi(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_CRYPTOLIB_FI_H_

--- a/sw/device/tests/penetrationtests/firmware/firmware_cryptolib.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_cryptolib.c
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include <stdbool.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+// Include commands
+#include "sw/device/tests/penetrationtests/json/commands.h"
+#include "sw/device/tests/penetrationtests/json/cryptolib_fi_commands.h"
+#include "sw/device/tests/penetrationtests/json/cryptolib_sca_commands.h"
+
+// Include handlers
+#include "fi/cryptolib_fi.h"
+#include "lib/extclk_sca_fi.h"
+#include "lib/pentest_lib.h"
+#include "sca/cryptolib_sca.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+status_t process_cmd(ujson_t *uj) {
+  while (true) {
+    penetrationtest_cmd_t cmd;
+    TRY(ujson_deserialize_penetrationtest_cmd_t(uj, &cmd));
+    switch (cmd) {
+      case kPenetrationtestCommandCryptoLibSca:
+        RESP_ERR(uj, handle_cryptolib_sca(uj));
+        break;
+      case kPenetrationtestCommandCryptoLibFi:
+        RESP_ERR(uj, handle_cryptolib_fi(uj));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", cmd);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  CHECK_STATUS_OK(entropy_complex_init());
+  ujson_t uj = ujson_ottf_console();
+  return status_ok(process_cmd(&uj));
+}

--- a/sw/device/tests/penetrationtests/firmware/sca/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/sca/BUILD
@@ -24,6 +24,23 @@ cc_library(
 )
 
 cc_library(
+    name = "cryptolib_sca",
+    srcs = ["cryptolib_sca.c"],
+    hdrs = ["cryptolib_sca.h"],
+    deps = [
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+        "//sw/device/tests/penetrationtests/json:cryptolib_sca_commands",
+    ],
+)
+
+cc_library(
     name = "ecc256_keygen_sca",
     srcs = ["ecc256_keygen_sca.c"],
     hdrs = ["ecc256_keygen_sca.h"],
@@ -93,12 +110,12 @@ cc_library(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:hmac_testutils",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:prng",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
         "//sw/device/tests/penetrationtests/json:hmac_sca_commands",
-        "//sw/device/lib/testing:hmac_testutils",
     ],
 )
 

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca.c
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h"
+#include "sw/device/tests/penetrationtests/json/cryptolib_sca_commands.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+status_t handle_cryptolib_sca_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_cpuctrl;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_cpuctrl));
+
+  pentest_select_trigger_type(kPentestTriggerTypeSw);
+  // As we are using the software defined trigger, the first argument of
+  // pentest_init is not needed. kPentestTriggerSourceAes is selected as a
+  // placeholder.
+  pentest_init(kPentestTriggerSourceAes,
+               kPentestPeripheralIoDiv4 | kPentestPeripheralEdn |
+                   kPentestPeripheralCsrng | kPentestPeripheralEntropy |
+                   kPentestPeripheralAes | kPentestPeripheralHmac |
+                   kPentestPeripheralKmac | kPentestPeripheralOtbn);
+
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+
+  // Read device ID and return to host.
+  TRY(pentest_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
+
+  return OK_STATUS();
+}
+
+status_t handle_cryptolib_sca(ujson_t *uj) {
+  cryptolib_sca_subcommand_t cmd;
+  TRY(ujson_deserialize_cryptolib_sca_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kCryptoLibScaSubcommandInit:
+      return handle_cryptolib_sca_init(uj);
+    default:
+      LOG_ERROR("Unrecognized CryptoLib SCA subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_CRYPTOLIB_SCA_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_CRYPTOLIB_SCA_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+/**
+ * Initialize CryptoLib command handler.
+ *
+ * This command is designed to setup the CryptoLib SCA firmware.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_cryptolib_sca_init(ujson_t *uj);
+
+/**
+ * CryptoLib SCA command handler.
+ *
+ * Command handler for the CryptoLib SCA command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_cryptolib_sca(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_CRYPTOLIB_SCA_H_

--- a/sw/device/tests/penetrationtests/json/BUILD
+++ b/sw/device/tests/penetrationtests/json/BUILD
@@ -11,6 +11,8 @@ cc_library(
     deps = [
         ":aes_sca_commands",
         ":crypto_fi_commands",
+        ":cryptolib_fi_commands",
+        ":cryptolib_sca_commands",
         ":edn_sca_commands",
         ":extclk_sca_fi_commands",
         ":hmac_sca_commands",
@@ -39,6 +41,20 @@ cc_library(
     name = "crypto_fi_commands",
     srcs = ["crypto_fi_commands.c"],
     hdrs = ["crypto_fi_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "cryptolib_fi_commands",
+    srcs = ["cryptolib_fi_commands.c"],
+    hdrs = ["cryptolib_fi_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "cryptolib_sca_commands",
+    srcs = ["cryptolib_sca_commands.c"],
+    hdrs = ["cryptolib_sca_commands.h"],
     deps = ["//sw/device/lib/ujson"],
 )
 

--- a/sw/device/tests/penetrationtests/json/commands.h
+++ b/sw/device/tests/penetrationtests/json/commands.h
@@ -15,6 +15,8 @@ extern "C" {
     value(_, AesSca) \
     value(_, AlertInfo) \
     value(_, CryptoFi) \
+    value(_, CryptoLibFi) \
+    value(_, CryptoLibSca) \
     value(_, EdnSca) \
     value(_, ExtClkScaFi) \
     value(_, HmacSca) \

--- a/sw/device/tests/penetrationtests/json/cryptolib_fi_commands.c
+++ b/sw/device/tests/penetrationtests/json/cryptolib_fi_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "cryptolib_fi_commands.h"

--- a/sw/device/tests/penetrationtests/json/cryptolib_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/cryptolib_fi_commands.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_CRYPTOLIB_FI_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_CRYPTOLIB_FI_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define CRYPTOLIBFI_SUBCOMMAND(_, value) \
+    value(_, Init)
+UJSON_SERDE_ENUM(CryptoLibFiSubcommand, cryptolib_fi_subcommand_t, CRYPTOLIBFI_SUBCOMMAND);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_CRYPTOLIB_FI_COMMANDS_H_

--- a/sw/device/tests/penetrationtests/json/cryptolib_sca_commands.c
+++ b/sw/device/tests/penetrationtests/json/cryptolib_sca_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "cryptolib_sca_commands.h"

--- a/sw/device/tests/penetrationtests/json/cryptolib_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/cryptolib_sca_commands.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_CRYPTOLIB_SCA_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_CRYPTOLIB_SCA_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define CRYPTOLIBSCA_SUBCOMMAND(_, value) \
+    value(_, Init)
+UJSON_SERDE_ENUM(CryptoLibScaSubcommand, cryptolib_sca_subcommand_t, CRYPTOLIBSCA_SUBCOMMAND);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_CRYPTOLIB_SCA_COMMANDS_H_


### PR DESCRIPTION
This commit adds stubs for the SCA and FI tests for the CryptoLib. In following commits, those stubs will be filled out with calls to the CryptoLib API.