### PR TITLE
[pentest] CharFlashRead/Write configure flash region

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/fi/BUILD
@@ -37,6 +37,7 @@ cc_library(
     hdrs = ["ibex_fi.h"],
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+        "//sw/device/lib/arch:boot_stage",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/tests/penetrationtests/firmware/fi/ibex_fi.h"
 
+#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/csr_registers.h"
 #include "sw/device/lib/base/memory.h"
@@ -80,6 +81,10 @@ uint32_t
     otp_data_read_ref_owner_sw_cfg[(OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
                                     OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE) /
                                    sizeof(uint32_t)];
+
+// CharFlash config parameters.
+static uint32_t flash_region_index;
+static uint32_t flash_test_page_addr;
 
 // Cond. branch macros.
 #define CONDBRANCHBEQ "beq x5, x6, endfitestfaultybeq\n"
@@ -2070,6 +2075,14 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) __attribute__((optnone)) {
 }
 
 status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
+  // Set the flash region we want to test.
+  ibex_fi_flash_region_t uj_data;
+  TRY(ujson_deserialize_ibex_fi_flash_region_t(uj, &uj_data));
+  if (uj_data.flash_region != flash_region_index) {
+    flash_region_index = uj_data.flash_region;
+    flash_init = false;
+  }
+
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
   // Clear the AST recoverable alerts.
@@ -2091,23 +2104,21 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
         .size = 0x1,
         .properties = region_properties};
 
-    dif_result_t res_prop =
-        dif_flash_ctrl_set_data_region_properties(&flash, 2, data_region);
-
-    dif_result_t res_en =
-        dif_flash_ctrl_set_data_region_enablement(&flash, 2, kDifToggleEnabled);
+    dif_result_t res_prop = dif_flash_ctrl_set_data_region_properties(
+        &flash, flash_region_index, data_region);
+    dif_result_t res_en = dif_flash_ctrl_set_data_region_enablement(
+        &flash, flash_region_index, kDifToggleEnabled);
     if (res_prop == kDifLocked || res_en == kDifLocked) {
-      LOG_INFO("Flash region locked.");
+      LOG_INFO("Flash region locked, aborting!");
       return ABORTED();
     }
 
     flash_init = true;
+    flash_test_page_addr = data_region.base * FLASH_PAGE_SZ;
   }
 
-  ptrdiff_t flash_bank_1_addr =
-      (ptrdiff_t)flash_info.data_pages * (ptrdiff_t)flash_info.bytes_per_page;
-  mmio_region_t flash_bank_1 = mmio_region_from_addr(
-      TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR + (uintptr_t)flash_bank_1_addr);
+  mmio_region_t flash_test_page = mmio_region_from_addr(
+      TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR + (uintptr_t)flash_test_page_addr);
 
   if (!flash_data_valid) {
     // Prepare page and write reference values into it.
@@ -2119,7 +2130,7 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
 
     // Erase flash and write page with reference values.
     TRY(flash_ctrl_testutils_erase_and_write_page(
-        &flash, (uint32_t)flash_bank_1_addr, /*partition_id=*/0, input_page,
+        &flash, flash_test_page_addr, /*partition_id=*/0, input_page,
         kDifFlashCtrlPartitionTypeData, FLASH_UINT32_WORDS_PER_PAGE));
 
     flash_data_valid = true;
@@ -2130,19 +2141,19 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
 
   // FI code target.
   PENTEST_ASM_TRIGGER_HIGH
-  asm volatile("lw x5, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x6, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x7, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x12, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x13, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x14, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x15, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x16, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x17, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x28, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x29, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x30, (%0)" : : "r"((flash_bank_1.base)));
-  asm volatile("lw x31, (%0)" : : "r"((flash_bank_1.base)));
+  asm volatile("lw x5, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x6, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x7, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x12, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x13, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x14, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x15, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x16, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x17, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x28, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x29, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x30, (%0)" : : "r"((flash_test_page.base)));
+  asm volatile("lw x31, (%0)" : : "r"((flash_test_page.base)));
   PENTEST_ASM_TRIGGER_LOW
 
   // Dump the register file after the FI trigger window.
@@ -2190,6 +2201,14 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
 }
 
 status_t handle_ibex_fi_char_flash_write(ujson_t *uj) __attribute__((optnone)) {
+  // Set the flash region we want to test.
+  ibex_fi_flash_region_t uj_data;
+  TRY(ujson_deserialize_ibex_fi_flash_region_t(uj, &uj_data));
+  if (uj_data.flash_region != flash_region_index) {
+    flash_region_index = uj_data.flash_region;
+    flash_init = false;
+  }
+
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
   // Clear the AST recoverable alerts.
@@ -2211,23 +2230,21 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) __attribute__((optnone)) {
         .size = 0x1,
         .properties = region_properties};
 
-    dif_result_t res_prop =
-        dif_flash_ctrl_set_data_region_properties(&flash, 2, data_region);
-
-    dif_result_t res_en =
-        dif_flash_ctrl_set_data_region_enablement(&flash, 2, kDifToggleEnabled);
+    dif_result_t res_prop = dif_flash_ctrl_set_data_region_properties(
+        &flash, flash_region_index, data_region);
+    dif_result_t res_en = dif_flash_ctrl_set_data_region_enablement(
+        &flash, flash_region_index, kDifToggleEnabled);
     if (res_prop == kDifLocked || res_en == kDifLocked) {
       LOG_INFO("Flash region locked, aborting!");
       return ABORTED();
     }
 
     flash_init = true;
+    flash_test_page_addr = data_region.base * FLASH_PAGE_SZ;
   }
 
-  ptrdiff_t flash_bank_1_addr =
-      (ptrdiff_t)flash_info.data_pages * (ptrdiff_t)flash_info.bytes_per_page;
-  mmio_region_t flash_bank_1 = mmio_region_from_addr(
-      TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR + (uintptr_t)flash_bank_1_addr);
+  mmio_region_t flash_test_page = mmio_region_from_addr(
+      TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR + (uintptr_t)flash_test_page_addr);
 
   // Prepare page and write reference values into it.
   uint32_t input_page[FLASH_UINT32_WORDS_PER_PAGE];
@@ -2240,7 +2257,7 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) __attribute__((optnone)) {
   PENTEST_ASM_TRIGGER_HIGH
   // Erase flash and write page with reference values.
   TRY(flash_ctrl_testutils_erase_and_write_page(
-      &flash, (uint32_t)flash_bank_1_addr, /*partition_id=*/0, input_page,
+      &flash, flash_test_page_addr, /*partition_id=*/0, input_page,
       kDifFlashCtrlPartitionTypeData, FLASH_UINT32_WORDS_PER_PAGE));
   PENTEST_ASM_TRIGGER_LOW
 
@@ -2254,7 +2271,7 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) __attribute__((optnone)) {
   uint32_t res = 0;
   for (int i = 0; i < kNumRefValues; i++) {
     res_values[i] =
-        mmio_region_read32(flash_bank_1, i * (ptrdiff_t)sizeof(uint32_t));
+        mmio_region_read32(flash_test_page, i * (ptrdiff_t)sizeof(uint32_t));
     if (res_values[i] != ref_values[i]) {
       res |= 1;
     }

--- a/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
@@ -122,6 +122,10 @@ UJSON_SERDE_STRUCT(IbexFiFaultyAddressData, ibex_fi_faulty_addresses_data_t, IBE
     field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiRfDump, ibex_fi_rf_dump_t, IBEXFI_RF_DUMP);
 
+#define IBEXFI_FLASH_REGION(field, string) \
+    field(flash_region, uint32_t)
+UJSON_SERDE_STRUCT(IbexFiFlashRegion, ibex_fi_flash_region_t, IBEXFI_FLASH_REGION);
+
 // clang-format on
 
 #ifdef __cplusplus

--- a/sw/host/penetrationtests/testvectors/data/fi_ibex.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_ibex.json
@@ -53,11 +53,13 @@
   {
     "test_case_id": 10,
     "command": "CharFlashRead",
+    "input": "{\"flash_region\": 2}",
     "expected_output": ["{\"data_faulty\":[false,false,false,false,false,false,false,false,false,false,false,false,false],\"data\":[0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   },
   {
     "test_case_id": 11,
     "command": "CharFlashWrite",
+    "input": "{\"flash_region\": 2}",
     "expected_output": ["{\"result\":0,\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   },
   {


### PR DESCRIPTION
Depending on the boot stage, different flash regions are available. This commit selects the correct flash region based on kBootStage.