### PR TITLE
[pentest] Filter state & counter for lc_lctrl_fi test

### DIFF
--- a/sw/host/tests/penetrationtests/fi_lc_ctrl/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_lc_ctrl/src/main.rs
@@ -44,6 +44,19 @@ struct FiLcCtrlTestCase {
     expected_output: Vec<String>,
 }
 
+fn filter_response(response: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    // Filter common items.
+    let response_common_filtered = filter_response_common(response.clone());
+    // Filter test-specifc items.
+    let mut map: serde_json::Map<String, serde_json::Value> = response_common_filtered.clone();
+    // Depending on the SKU, the life cycle state and counter could be different.
+    // Hence, filter it.
+    map.remove("state");
+    map.remove("counter");
+
+    map
+}
+
 fn run_fi_lc_ctrl_testcase(
     test_case: &FiLcCtrlTestCase,
     opts: &Opts,
@@ -80,12 +93,12 @@ fn run_fi_lc_ctrl_testcase(
             )?;
             // Only check non empty JSON responses.
             if output.as_object().is_some() {
-                let output_received = filter_response_common(output.clone());
+                let output_received = filter_response(output.clone());
 
                 // Filter expected output.
                 let exp_output: serde_json::Value =
                     serde_json::from_str(exp_output.as_str()).unwrap();
-                let output_expected = filter_response_common(exp_output.clone());
+                let output_expected = filter_response(exp_output.clone());
 
                 // Check received with expected output.
                 if output_expected != output_received {


### PR DESCRIPTION
Depending on the SKU config, the target could be in a different life cycle state and life cycle counter. Hence, it does not make sense to compare these two values with the testvector. However, if there would be a mismatch between LC state & counter before and after the FI trigger window, the "res" field indicates this.