### PR TITLE
[pentest] Fix A2 signing

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -11,6 +11,7 @@ load(
     "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "EARLGREY_TEST_ENVS",
     "fpga_params",
+    "opentitan_binary",
     "opentitan_test",
     "silicon_params",
 )


### PR DESCRIPTION
Add the opentitan_binary target in firmware BUILD.