### PR TITLE
[pentest] Fixes and masking

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_asym_impl.c
@@ -70,15 +70,19 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
   TRY_CHECK(num_bytes == uj_input.n_len);
 
   otcrypto_hash_mode_t hash_mode;
+  size_t hash_digest_bytes;
   switch (uj_input.hashing) {
     case kPentestRsaHashmodeSha256:
       hash_mode = kOtcryptoHashModeSha256;
+      hash_digest_bytes = kSha256DigestBytes;
       break;
     case kPentestRsaHashmodeSha384:
       hash_mode = kOtcryptoHashModeSha384;
+      hash_digest_bytes = kSha384DigestBytes;
       break;
     case kPentestRsaHashmodeSha512:
       hash_mode = kOtcryptoHashModeSha512;
+      hash_digest_bytes = kSha512DigestBytes;
       break;
     default:
       LOG_ERROR("Unsupported RSA hash mode: %d", uj_input.hashing);
@@ -207,10 +211,11 @@ status_t cryptolib_fi_rsa_enc_impl(cryptolib_fi_asym_rsa_enc_in_t uj_input,
     };
 
     // Create output buffer for the plaintext.
-    uint8_t plaintext_buf[RSA_CMD_MAX_MESSAGE_BYTES];
+    size_t kMaxPlaintextBytes = num_bytes - 2 * hash_digest_bytes - 2;
+    uint8_t plaintext_buf[kMaxPlaintextBytes];
     otcrypto_byte_buf_t plaintext = {
         .data = plaintext_buf,
-        .len = num_words,
+        .len = kMaxPlaintextBytes,
     };
 
     size_t msg_len;

--- a/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/cryptolib_fi_sym_impl.c
@@ -101,11 +101,16 @@ status_t cryptolib_fi_aes_impl(cryptolib_fi_sym_aes_in_t uj_input,
   // Create buffer to store key.
   uint32_t key_buf[kPentestAesMaxKeyWords];
   memset(key_buf, 0, AES_CMD_MAX_KEY_BYTES);
-  memcpy(key_buf, uj_input.key, sizeof(uj_input.key));
+  memcpy(key_buf, uj_input.key, uj_input.key_len);
   // Create keyblob.
   uint32_t keyblob[keyblob_num_words(config)];
   // Create blinded key.
-  TRY(keyblob_from_key_and_mask(key_buf, kAesKeyMask, config, keyblob));
+  uint32_t aes_key_mask[kPentestAesMaxKeyWords];
+  memset(aes_key_mask, 0, AES_CMD_MAX_KEY_BYTES);
+  for (size_t it = 0; it < kPentestAesMaxKeyWords; it++) {
+    aes_key_mask[it] = pentest_ibex_rnd32_read();
+  }
+  TRY(keyblob_from_key_and_mask(key_buf, aes_key_mask, config, keyblob));
   otcrypto_blinded_key_t key = {
       .config = config,
       .keyblob_length = sizeof(keyblob),
@@ -210,8 +215,15 @@ status_t cryptolib_fi_gcm_impl(cryptolib_fi_sym_gcm_in_t uj_input,
   memset(key_buf, 0, AES_CMD_MAX_KEY_BYTES);
   memcpy(key_buf, uj_input.key, uj_input.key_len);
 
+  // Create random mask.
+  uint32_t aes_key_mask[kPentestAesMaxKeyWords];
+  memset(aes_key_mask, 0, AES_CMD_MAX_KEY_BYTES);
+  for (size_t it = 0; it < kPentestAesMaxKeyWords; it++) {
+    aes_key_mask[it] = pentest_ibex_rnd32_read();
+  }
+
   uint32_t keyblob[keyblob_num_words(config)];
-  TRY(keyblob_from_key_and_mask(key_buf, kAesKeyMask, config, keyblob));
+  TRY(keyblob_from_key_and_mask(key_buf, aes_key_mask, config, keyblob));
 
   // Construct the blinded key.
   otcrypto_blinded_key_t key = {
@@ -327,12 +339,20 @@ status_t cryptolib_fi_hmac_impl(cryptolib_fi_sym_hmac_in_t uj_input,
   };
 
   // Create buffer to store key.
-  uint32_t key_buf[uj_input.key_len];
+
+  // Create buffer to store key.
+  uint32_t key_buf[kPentestHmacMaxKeyWords];
+  memset(key_buf, 0, HMAC_CMD_MAX_KEY_BYTES);
   memcpy(key_buf, uj_input.key, uj_input.key_len);
   // Create keyblob.
   uint32_t keyblob[keyblob_num_words(config)];
   // Create blinded key.
-  TRY(keyblob_from_key_and_mask(key_buf, kHmacMask, config, keyblob));
+  uint32_t hmac_key_mask[kPentestHmacMaxKeyWords];
+  memset(hmac_key_mask, 0, HMAC_CMD_MAX_KEY_BYTES);
+  for (size_t it = 0; it < kPentestHmacMaxKeyWords; it++) {
+    hmac_key_mask[it] = pentest_ibex_rnd32_read();
+  }
+  TRY(keyblob_from_key_and_mask(key_buf, hmac_key_mask, config, keyblob));
   otcrypto_blinded_key_t key = {
       .config = config,
       .keyblob_length = sizeof(keyblob),

--- a/sw/device/tests/penetrationtests/firmware/lib/cryptolib_sym.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/cryptolib_sym.h
@@ -29,9 +29,13 @@ enum {
    */
   kPentestAesBlockWords = AES_CMD_MAX_BLOCK_BYTES / sizeof(uint32_t),
   /**
-   * Number of words in a key.
+   * Number of words in an AES key.
    */
   kPentestAesMaxKeyWords = AES_CMD_MAX_KEY_BYTES / sizeof(uint32_t),
+  /**
+   * Number of words in a HMAC key.
+   */
+  kPentestHmacMaxKeyWords = HMAC_CMD_MAX_KEY_BYTES / sizeof(uint32_t),
   /**
    * HMAC mode definitions.
    */
@@ -48,23 +52,6 @@ enum {
    * Number of max words in a tag.
    */
   kPentestHmacMaxTagWords = HMAC_CMD_MAX_TAG_BYTES / sizeof(uint32_t),
-};
-
-// Arbitrary mask for testing (borrowed from aes_functest.c).
-static const uint32_t kAesKeyMask[8] = {
-    0x1b81540c, 0x220733c9, 0x8bf85383, 0x05ab50b4,
-    0x8acdcb7e, 0x15e76440, 0x8459b2ce, 0xdc2110cc,
-};
-
-static const uint32_t kHmacMask[48] = {
-    0xBA81767F, 0xA913C751, 0x34209992, 0x5F66021B, 0x775F4577, 0x7C02E1CE,
-    0xB4A8B698, 0x1986B902, 0x7251045B, 0x3C827C6F, 0x00909D12, 0x81ABC8F9,
-    0x62F2FCB6, 0x15B63124, 0x66F60052, 0xAD637669, 0x522779CF, 0x07E9FBA8,
-    0x1258E541, 0x860719EF, 0x1D4F5386, 0xA9B04F7C, 0x6E98A861, 0xEFADEBA6,
-    0x900E1EC8, 0xB290DBCE, 0x05946814, 0xB83A01CE, 0x4EEC86BD, 0xAE836C6C,
-    0x20182AAE, 0x4476F6F4, 0x7C4A0A31, 0x7D2809BA, 0x367B29B9, 0x42444BEA,
-    0xDFD6025C, 0x1E665207, 0x18E0895B, 0x20D435DB, 0xC509A6D6, 0x8CC19AB1,
-    0xA5D39BD2, 0xAB479AD5, 0x5786D029, 0x2E4B7CD7, 0xB77A3D76, 0xE2A09962,
 };
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_LIB_CRYPTOLIB_SYM_H_

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -40,6 +40,7 @@
 #include "clkmgr_regs.h"  // Generated
 #include "csrng_regs.h"   // Generated
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rv_core_ibex_regs.h"  // Generated
 
 #if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/lib/crypto/drivers/otbn.h"
@@ -1227,4 +1228,20 @@ status_t pentest_send_sku_config(ujson_t *uj) {
   RESP_OK(ujson_serialize_string, uj, PENTEST_VERSION);
 
   return OK_STATUS();
+}
+
+static void wait_rnd_valid(void) {
+  while (true) {
+    uint32_t reg = abs_mmio_read32(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR +
+                                   RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
+    if (bitfield_bit32_read(reg, RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT)) {
+      return;
+    }
+  }
+}
+
+uint32_t pentest_ibex_rnd32_read(void) {
+  wait_rnd_valid();
+  return abs_mmio_read32(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR +
+                         RV_CORE_IBEX_RND_DATA_REG_OFFSET);
 }

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -541,4 +541,12 @@ status_t pentest_read_rstmgr_alert_info(ujson_t *uj);
  */
 status_t pentest_send_sku_config(ujson_t *uj);
 
+/**
+ * Read the Ibex RND register.
+ *
+ * Blocks until data is available in the Ibex RND register. Rnd data comes from
+ * the EDN.
+ */
+uint32_t pentest_ibex_rnd32_read(void);
+
 #endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_LIB_PENTEST_LIB_H_

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_asym_impl.c
@@ -72,15 +72,19 @@ status_t cryptolib_sca_rsa_dec_impl(
   TRY_CHECK(num_bytes == data_len);
 
   otcrypto_hash_mode_t hash_mode;
+  size_t hash_digest_bytes;
   switch (hashing) {
     case kPentestRsaHashmodeSha256:
       hash_mode = kOtcryptoHashModeSha256;
+      hash_digest_bytes = kSha256DigestBytes;
       break;
     case kPentestRsaHashmodeSha384:
       hash_mode = kOtcryptoHashModeSha384;
+      hash_digest_bytes = kSha384DigestBytes;
       break;
     case kPentestRsaHashmodeSha512:
       hash_mode = kOtcryptoHashModeSha512;
+      hash_digest_bytes = kSha512DigestBytes;
       break;
     default:
       LOG_ERROR("Unsupported RSA hash mode: %d", hashing);
@@ -157,10 +161,11 @@ status_t cryptolib_sca_rsa_dec_impl(
                                          .len = kTestLabelLen};
 
   // Create output buffer for the plaintext.
-  uint8_t plaintext_buf[RSA_CMD_MAX_MESSAGE_BYTES];
+  size_t kMaxPlaintextBytes = num_bytes - 2 * hash_digest_bytes - 2;
+  uint8_t plaintext_buf[kMaxPlaintextBytes];
   otcrypto_byte_buf_t plaintext = {
       .data = plaintext_buf,
-      .len = num_words,
+      .len = kMaxPlaintextBytes,
   };
 
   size_t msg_len;

--- a/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym_impl.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/cryptolib_sca_sym_impl.c
@@ -111,7 +111,12 @@ status_t cryptolib_sca_aes_impl(uint8_t data_in[AES_CMD_MAX_MSG_BYTES],
   // Create keyblob.
   uint32_t keyblob[keyblob_num_words(config)];
   // Create blinded key.
-  TRY(keyblob_from_key_and_mask(key_buf, kAesKeyMask, config, keyblob));
+  uint32_t aes_key_mask[kPentestAesMaxKeyWords];
+  memset(aes_key_mask, 0, AES_CMD_MAX_KEY_BYTES);
+  for (size_t it = 0; it < kPentestAesMaxKeyWords; it++) {
+    aes_key_mask[it] = pentest_ibex_rnd32_read();
+  }
+  TRY(keyblob_from_key_and_mask(key_buf, aes_key_mask, config, keyblob));
   otcrypto_blinded_key_t aes_key = {
       .config = config,
       .keyblob_length = sizeof(keyblob),
@@ -223,14 +228,21 @@ status_t cryptolib_sca_gcm_impl(
       .security_level = kOtcryptoKeySecurityLevelLow,
   };
 
-  // Construct blinded key from the key and testing mask.
+  // Construct blinded key from the key and mask.
   uint32_t key_buf[kPentestAesMaxKeyWords];
   memset(key_buf, 0, AES_CMD_MAX_KEY_BYTES);
   memcpy(key_buf, key, key_len);
 
+  // Create random mask.
+  uint32_t aes_key_mask[kPentestAesMaxKeyWords];
+  memset(aes_key_mask, 0, AES_CMD_MAX_KEY_BYTES);
+  for (size_t it = 0; it < kPentestAesMaxKeyWords; it++) {
+    aes_key_mask[it] = pentest_ibex_rnd32_read();
+  }
+
   uint32_t keyblob[keyblob_num_words(config)];
-  TRY(keyblob_from_key_and_mask(key_buf, kAesKeyMask, config, keyblob));
-  LOG_INFO("GCM IMPl1");
+  TRY(keyblob_from_key_and_mask(key_buf, aes_key_mask, config, keyblob));
+
   // Construct the blinded key.
   otcrypto_blinded_key_t gcm_key = {
       .config = config,
@@ -241,7 +253,7 @@ status_t cryptolib_sca_gcm_impl(
 
   // Set the checksum.
   gcm_key.checksum = integrity_blinded_checksum(&gcm_key);
-  LOG_INFO("GCM IMPl1");
+
   // Prepare the input buffers.
   size_t iv_num_words = 4;
   uint32_t iv_data[iv_num_words];
@@ -354,7 +366,12 @@ status_t cryptolib_sca_hmac_impl(uint8_t data_in[HMAC_CMD_MAX_MSG_BYTES],
   // Create keyblob.
   uint32_t keyblob[keyblob_num_words(config)];
   // Create blinded key.
-  TRY(keyblob_from_key_and_mask(key_buf, kHmacMask, config, keyblob));
+  uint32_t hmac_key_mask[kPentestHmacMaxKeyWords];
+  memset(hmac_key_mask, 0, HMAC_CMD_MAX_KEY_BYTES);
+  for (size_t it = 0; it < kPentestHmacMaxKeyWords; it++) {
+    hmac_key_mask[it] = pentest_ibex_rnd32_read();
+  }
+  TRY(keyblob_from_key_and_mask(key_buf, hmac_key_mask, config, keyblob));
   otcrypto_blinded_key_t hmac_key = {
       .config = config,
       .keyblob_length = sizeof(keyblob),


### PR DESCRIPTION
- Fix a bug in the RSA decryption buffer
- Use randomness for the mask for sym. CL implementation