### PR TITLE
[pentest] Add HMAC FI options

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/fi/BUILD
@@ -11,6 +11,7 @@ cc_library(
     deps = [
         "//hw/ip/aes/data:aes_c_regs",
         "//hw/ip/kmac/data:kmac_c_regs",
+        "//hw/ip/hmac/data:hmac_c_regs",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",

--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.h
@@ -53,15 +53,20 @@ status_t handle_crypto_fi_kmac(ujson_t *uj);
 status_t handle_crypto_fi_kmac_state(ujson_t *uj);
 
 /**
- * SHA256 FI test.
+ * HMAC FI test.
  *
- * Receive message & trigger configuration from host. Perform SHA256 operation
- * and return the digest back to the host.
+ * Receive message & trigger configuration from host. Perform SHA2 or HMAC
+ * operation and return the digest back to the host.
+ *
+ * There are triggers over each interface function.
+ * The HMAC has the option to swap the endianness of its message, key, or
+ * digest, and it accepts its mode to be in SHA256, SHA384, or SHA512. Enable
+ * hmac means that HMAC is used, otherwise SHA2 is used.
  *
  * @param uj An initialized uJSON context.
  * @return OK or error.
  */
-status_t handle_crypto_fi_sha256(ujson_t *uj);
+status_t handle_crypto_fi_hmac(ujson_t *uj);
 
 /**
  * Shadow Register Access FI test.

--- a/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.h
@@ -38,6 +38,8 @@ status_t handle_hmac_sca_batch_fvsr(ujson_t *uj);
  * using a random dataset. This dataset is generated on the device using the
  * PRNG from the SCA library.
  *
+ * Note that the key is presumed to be correctly padded or hashed already.
+ *
  * SCA traces are captured during trigger_high & trigger_low.
  *
  * @param uj An initialized uJSON context.
@@ -52,6 +54,8 @@ status_t handle_hmac_sca_batch_random(ujson_t *uj);
  * by re-using the output of the HMAC by its input. This dataset is generated on
  * the device using the PRNG from the SCA library.
  *
+ * Note that the key is presumed to be correctly padded or hashed already.
+ *
  * SCA traces are captured during trigger_high & trigger_low.
  *
  * @param uj An initialized uJSON context.
@@ -64,6 +68,8 @@ status_t handle_hmac_sca_batch_daisy_chain(ujson_t *uj);
  *
  * This SCA penetration test triggers a single HMAC-SHA256 operation using the
  * provided key, mask, and message. The tag is returend to the host.
+ *
+ * Note that the key is presumed to be correctly padded or hashed already.
  *
  * SCA traces are captured during trigger_high & trigger_low.
  *

--- a/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
@@ -10,8 +10,8 @@ extern "C" {
 #endif
 
 #define CRYPTOFI_HMAC_CMD_MAX_MESSAGE_BYTES 16
-#define CRYPTOFI_HMAC_CMD_MAX_KEY_BYTES 32
-#define CRYPTOFI_HMAC_CMD_MAX_TAG_WORDS 8
+#define CRYPTOFI_HMAC_CMD_MAX_KEY_WORDS 16
+#define CRYPTOFI_HMAC_CMD_MAX_TAG_WORDS 16
 
 // clang-format off
 
@@ -20,7 +20,7 @@ extern "C" {
     value(_, Init) \
     value(_, Kmac) \
     value(_, KmacState) \
-    value(_, Sha256) \
+    value(_, Hmac) \
     value(_, ShadowRegAccess) \
     value(_, ShadowRegRead)
 C_ONLY(UJSON_SERDE_ENUM(CryptoFiSubcommand, crypto_fi_subcommand_t, CRYPTOFI_SUBCOMMAND));
@@ -71,9 +71,10 @@ UJSON_SERDE_STRUCT(FiKmacDigest, crypto_fi_kmac_digest_t, CRYPTOFI_KMAC_DIGEST);
     field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(CRYPTOFITestResultMult, crypto_fi_test_result_mult_t, CRYPTOFI_TEST_RESULT_MULT);
 
-#define CRYPTOFI_HMAC_MESSAGE(field, string) \
-    field(message, uint8_t, CRYPTOFI_HMAC_CMD_MAX_MESSAGE_BYTES)
-UJSON_SERDE_STRUCT(FiHmacMessage, crypto_fi_hmac_message_t, CRYPTOFI_HMAC_MESSAGE);
+#define CRYPTOFI_HMAC_INPUT(field, string) \
+    field(message, uint8_t, CRYPTOFI_HMAC_CMD_MAX_MESSAGE_BYTES) \
+    field(key, uint32_t, CRYPTOFI_HMAC_CMD_MAX_KEY_WORDS)
+UJSON_SERDE_STRUCT(FiHmacInput, crypto_fi_hmac_input_t, CRYPTOFI_HMAC_INPUT);
 
 #define CRYPTOFI_HMAC_TAG(field, string) \
     field(tag, uint32_t, CRYPTOFI_HMAC_CMD_MAX_TAG_WORDS) \
@@ -86,7 +87,12 @@ UJSON_SERDE_STRUCT(FiHmacTag, crypto_fi_hmac_tag_t, CRYPTOFI_HMAC_TAG);
     field(start_trigger, bool) \
     field(msg_trigger, bool) \
     field(process_trigger, bool) \
-    field(finish_trigger, bool)
+    field(finish_trigger, bool) \
+    field(enable_hmac, bool) \
+    field(message_endianness_big, bool) \
+    field(digest_endianness_big, bool) \
+    field(key_endianness_big, bool) \
+    field(hash_mode, uint32_t)
 UJSON_SERDE_STRUCT(CryptoFiHmacMode, crypto_fi_hmac_mode_t, CRYPTOFI_HMAC_MODE);
 
 // clang-format on

--- a/sw/host/penetrationtests/testvectors/data/fi_crypto.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_crypto.json
@@ -69,39 +69,95 @@
   },
   {
     "test_case_id": 11,
-    "command": "Sha256",
-    "input": "{\"message\": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}",
-    "mode": "{\"start_trigger\": true,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": false}",
-    "expected_output": ["{\"tag\":[686569403,627255979,3962665531,1869430007,3580678696,2543765621,4151418325,927402239],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+    "command": "Hmac",
+    "input": "{\"message\": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], \"key\": [0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": true,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": false, \"enable_hmac\": false, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":0}",
+    "expected_output": ["{\"tag\":[686569403,627255979,3962665531,1869430007,3580678696,2543765621,4151418325,927402239,0, 0, 0, 0, 0, 0, 0, 0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   },
   {
     "test_case_id": 12,
-    "command": "Sha256",
-    "input": "{\"message\": [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]}",
-    "mode": "{\"start_trigger\": false,\"msg_trigger\": true,\"process_trigger\": false,\"finish_trigger\": false}",
-    "expected_output": ["{\"tag\":[1080378907,3894047529,4265098468,2275438372,2555095219,287412521,1595297801,1522967956],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+    "command": "Hmac",
+    "input": "{\"message\": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], \"key\": [0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": true,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": false, \"enable_hmac\": false, \"message_endianness_big\": true, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":0}",
+    "expected_output": ["{\"tag\":[686569403,627255979,3962665531,1869430007,3580678696,2543765621,4151418325,927402239,0, 0, 0, 0, 0, 0, 0, 0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   },
   {
     "test_case_id": 13,
-    "command": "Sha256",
-    "input": "{\"message\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}",
-    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": true,\"finish_trigger\": false}",
-    "expected_output": ["{\"tag\":[3996813713,3685128488,2749163006,1137088592,438890749,3186001028,96417470,3192245030],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+    "command": "Hmac",
+    "input": "{\"message\": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], \"key\": [0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": true,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": false, \"enable_hmac\": false, \"message_endianness_big\": true, \"digest_endianness_big\": true, \"key_endianness_big\": false, \"hash_mode\":0}",
+    "expected_output": ["{\"tag\":[3141004328,2871681829,997863916,4147932527,684879061,1976082071,3583865335,4278732599,0, 0, 0, 0, 0, 0, 0, 0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   },
   {
     "test_case_id": 14,
-    "command": "Sha256",
-    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]}",
-    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true}",
-    "expected_output": ["{\"tag\":[956051232,3683224361,4139697432,3225996988,496274419,3147268997,3136358402,529633942],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+    "command": "Hmac",
+    "input": "{\"message\": [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": true,\"process_trigger\": false,\"finish_trigger\": false, \"enable_hmac\": false, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":0}",
+    "expected_output": ["{\"tag\":[1080378907,3894047529,4265098468,2275438372,2555095219,287412521,1595297801,1522967956,0, 0, 0, 0, 0, 0, 0, 0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   },
   {
     "test_case_id": 15,
+    "command": "Hmac",
+    "input": "{\"message\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], \"key\": [0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": true,\"finish_trigger\": false, \"enable_hmac\": false, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":0}",
+    "expected_output": ["{\"tag\":[3996813713,3685128488,2749163006,1137088592,438890749,3186001028,96417470,3192245030,0, 0, 0, 0, 0, 0, 0, 0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+  },
+  {
+    "test_case_id": 16,
+    "command": "Hmac",
+    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], \"key\": [0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true, \"enable_hmac\": false, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":0}",
+    "expected_output": ["{\"tag\":[956051232,3683224361,4139697432,3225996988,496274419,3147268997,3136358402,529633942,0, 0, 0, 0, 0, 0, 0, 0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+  },
+  {
+    "test_case_id": 17,
+    "command": "Hmac",
+    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], \"key\": [0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true, \"enable_hmac\": false, \"message_endianness_big\": true, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":0}",
+    "expected_output": ["{\"tag\":[2856256064,3909088473,1660650950,4117743022,1622899107,107234495,3357956274,284642735,0, 0, 0, 0, 0, 0, 0, 0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+  },
+  {
+    "test_case_id": 18,
+    "command": "Hmac",
+    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], \"key\": [0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true, \"enable_hmac\": false, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":1}",
+    "expected_output": ["{\"tag\":[956794333,2962363795,807320094,1443896907,450466098,1195137667,4279831992,1530897902,2770728890,2252409361,1392239866,1021544579,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+  },
+  {
+    "test_case_id": 19,
+    "command": "Hmac",
+    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], \"key\": [0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true, \"enable_hmac\": false, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":2}",
+    "expected_output": ["{\"tag\":[1817511279,2381723475,1333175416,3289336254,21289985,2726264315,3303817390,1284292231,1189285626,4048996872,1452280734,2335544134,1687508487,592318096,467060269,2055378582],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+  },
+  {
+    "test_case_id": 20,
+    "command": "Hmac",
+    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], \"key\": [0, 1, 2, 3, 4, 5, 6, 7]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true, \"enable_hmac\": true, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":0}",
+    "expected_output": ["{\"tag\":[1718936401,3934232619,660172194,642293994,832111426,1447558433,2262381463,704814822,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+  },
+  {
+    "test_case_id": 21,
+    "command": "Hmac",
+    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], \"key\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true, \"enable_hmac\": true, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":1}",
+    "expected_output": ["{\"tag\":[2002654839,2171821763,3734709844,319069890,1658767967,3907547394,2147427249,4285135042,1044645490,565219722,532991724,696101234,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+  },
+  {
+    "test_case_id": 22,
+    "command": "Hmac",
+    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0], \"key\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true, \"enable_hmac\": true, \"message_endianness_big\": false, \"digest_endianness_big\": false, \"key_endianness_big\": false, \"hash_mode\":2}",
+    "expected_output": ["{\"tag\":[1709257561,1763202480,856627814,1141678823,3814690376,1695667148,1632553365,1215934345,820770384,1324704972,714820083,1277918871,1632724788,331654792,1853992088,827702048],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
+  },
+  {
+    "test_case_id": 23,
     "command": "ShadowRegAccess",
     "expected_output": ["{\"result\":[68162304,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   },
   {
-    "test_case_id": 16,
+    "test_case_id": 24,
     "command": "ShadowRegRead",
     "expected_output": ["{\"result\":[0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   }


### PR DESCRIPTION
Add options to the HMAC FI test (previously the SHA2 test) to set the mode and endianness of the SHA2/HMAC.