### PR TITLE
[pentest] Add A2 for testing

### DIFF
--- a/sw/device/tests/penetrationtests/pentest.bzl
+++ b/sw/device/tests/penetrationtests/pentest.bzl
@@ -11,6 +11,10 @@ load(
     "opentitan_test",
     "silicon_params",
 )
+load(
+    "@provisioning_exts//:cfg.bzl",
+    "EXT_EXEC_ENV_SILICON_ROM_EXT_A2",
+)
 
 # Defines default execution environments for penetrationtests targets. All
 # opentitan_test must have the following attributes to configure
@@ -23,7 +27,7 @@ PENTEST_EXEC_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
     "//hw/top_earlgrey:fpga_cw340_test_rom": "fpga_cw340",
     "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": "fpga_cw340",
-} | EARLGREY_SILICON_OWNER_ROM_EXT_ENVS
+} | EARLGREY_SILICON_OWNER_ROM_EXT_ENVS | EXT_EXEC_ENV_SILICON_ROM_EXT_A2
 
 FIRMWARE_DEPS_FI = [
     "//sw/device/tests/penetrationtests/firmware/fi:crypto_fi",


### PR DESCRIPTION
We currently did not add the new exec environment for A2 for the sw/device/tests/penetrationtests/pentest.bzl. This adds the environment allowing for A2 testing of the testOS.