### PR TITLE
[pentest] Bugfix csr_combi test

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -2120,6 +2120,11 @@ status_t handle_ibex_fi_char_csr_combi(ujson_t *uj) {
   cfg = bitfield_bit32_write(cfg, HMAC_CFG_SHA_EN_BIT, false);
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, cfg);
 
+  // Make explicit register variables for the test
+  register volatile uint32_t reg_x9  asm("x9");
+  register volatile uint32_t reg_x19 asm("x19");
+  register volatile uint32_t reg_x29 asm("x29");
+
   // Write reference value into CSR.
   if (uj_data.trigger & 0x1) {
     PENTEST_ASM_TRIGGER_HIGH
@@ -2164,9 +2169,9 @@ status_t handle_ibex_fi_char_csr_combi(ujson_t *uj) {
       TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
           ALERT_HANDLER_CLASSA_ACCUM_THRESH_SHADOWED_REG_OFFSET,
       uj_data.ref_values[13]);
-  asm volatile("mv x9, %0" : : "r"(uj_data.ref_values[14]));
-  asm volatile("mv x19, %0" : : "r"(uj_data.ref_values[15]));
-  asm volatile("mv x29, %0" : : "r"(uj_data.ref_values[16]));
+  reg_x9 = uj_data.ref_values[14];
+  reg_x19 = uj_data.ref_values[15];
+  reg_x29 = uj_data.ref_values[16];
   if (uj_data.trigger & 0x1) {
     PENTEST_ASM_TRIGGER_LOW
   }
@@ -2214,9 +2219,9 @@ status_t handle_ibex_fi_char_csr_combi(ujson_t *uj) {
   read_csrs[13] =
       abs_mmio_read32(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR +
                       ALERT_HANDLER_CLASSA_ACCUM_THRESH_SHADOWED_REG_OFFSET);
-  asm volatile("mv %0, x9" : "=r"(read_csrs[14]));
-  asm volatile("mv %0, x19" : "=r"(read_csrs[15]));
-  asm volatile("mv %0, x29" : "=r"(read_csrs[16]));
+  read_csrs[14] = reg_x9;
+  read_csrs[15] = reg_x19;
+  read_csrs[16] = reg_x29;
   if (uj_data.trigger & 0x4) {
     PENTEST_ASM_TRIGGER_LOW
   }

--- a/sw/host/penetrationtests/testvectors/data/fi_ibex.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_ibex.json
@@ -196,13 +196,13 @@
   {
     "test_case_id": 37,
     "command": "CharCsrCombi",
-    "input": "{\"trigger\": 0, \"ref_values\": [2,3,16641,4,5,6,38553,7,5137,256,26214,26214,26214,5,2,3,4]}",
+    "input": "{\"trigger\": 7, \"ref_values\": [2,3,16641,4,5,6,38553,7,5137,256,26214,26214,26214,5,2,3,4]}",
     "expected_output": ["{\"output\":[2,3,16641,4,5,6,38553,7,5137,256,26214,26214,26214,5,2,3,4], \"data_faulty\": [false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false], \"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   },
   {
     "test_case_id": 38,
     "command": "CharCsrCombi",
-    "input": "{\"trigger\": 0, \"ref_values\": [1,5,33,101,3,5,39321,6,5138,50115,39321,38502,39321,39321,1,2,3]}",
+    "input": "{\"trigger\": 7, \"ref_values\": [1,5,33,101,3,5,39321,6,5138,50115,39321,38502,39321,39321,1,2,3]}",
     "expected_output": ["{\"output\":[1,5,33,101,3,5,39321,6,5138,50115,39321,38502,39321,39321,1,2,3], \"data_faulty\": [false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false], \"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"]
   }
 ]


### PR DESCRIPTION
The CSR combi test writes values to working registers to read them out later. The triggers in between the test can interfere with those. Instead, use the volatile register variable in C in order to make it clear that those registers should not be overwritten to make the test stable.