### PR TITLE
[pentest] Update aes sca

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.h
@@ -9,276 +9,6 @@
 #include "sw/device/lib/ujson/ujson.h"
 
 /**
- * Simple serial 'a' (alternative batch encrypt) command handler.
- *
- * This command is designed to maximize the capture rate for side-channel
- * attacks. It uses the first supplied plaintext and repeats AES encryptions
- * by using every ciphertext as next plaintext with a constant key. This
- * minimizes the overhead of UART communication and significantly improves the
- * capture rate.
-
- * Packet payload must be a `uint32_t` representation of the number of
- * encryptions to perform. Since generated plaintexts are not cached, there is
- * no limit on the number of encryptions.
- *
- * The key should also be set using 'k' (key set) command.
- *
- * The host can verify the operation by checking the last 'r' (ciphertext)
- * packet that is sent at the end.
- *
- * The uJSON data contains:
- *  - data: The number of encryptions.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_batch_alternative_encrypt(ujson_t *uj);
-
-/**
- * Batch encrypt command handler.
- *
- * This command is designed to maximize the capture rate for side-channel
- * attacks. Instead of expecting a plaintext and sending the resulting
- * ciphertext from and to the host for each encryption, this command repeatedly
- * encrypts random plaintexts that are generated on the device. This minimizes
- * the overhead of UART communication and significantly improves the capture
- * rate. The host must use the same PRNG to be able to compute the plaintext and
- * the ciphertext of each trace.
- *
- * Packet payload must be a `uint32_t` representation of the number of
- * encryptions to perform. Since generated plaintexts are not cached, there is
- * no limit on the number of encryptions.
- *
- * The PRNG should be initialized using the seed PRNG command before
- * starting batch encryption. In addition, the key should also be set
- * using key set command before starting batch captures.
- *
- * Note that the host can partially verify this operation by checking the
- * contents of UART reponse that is sent at the end.
- *
- * The uJSON data contains:
- *  - data: The number of encryptions.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_batch_encrypt(ujson_t *uj);
-
-/**
- * Batch encrypt random command handler.
- *
- * This command is designed to maximize the capture rate for side-channel
- * attacks. Instead of expecting a plaintext and sending the resulting
- * ciphertext from and to the host for each encryption, this command repeatedly
- * encrypts random plaintexts that are generated on the device. This minimizes
- * the overhead of UART communication and significantly improves the capture
- * rate. The host must use the same PRNG to be able to compute the plaintext and
- * the ciphertext of each trace.
- *
- * Packet payload must be a `uint32_t` representation of the number of
- * encryptions to perform. Since generated plaintexts are not cached, there is
- * no limit on the number of encryptions.
- *
- * The PRNG should be initialized using the seed PRNG command before
- * starting batch encryption. In addition, the key should also be set
- * using key set command before starting batch captures.
- *
- * Note that the host can partially verify this operation by checking the
- * contents of UART reponse that is sent at the end.
- *
- * The uJSON data contains:
- *  - data: The number of encryptions.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_batch_encrypt_random(ujson_t *uj);
-
-/**
- * Batch plaintext command handler.
- *
- * This command is designed to set the initial plaintext for
- * aes_serial_batch_alternative_encrypt.
- *
- * The plaintext must be `kAesTextLength` bytes long.
- *
- *  * The uJSON data contains:
- *  - text: The plaintext.
- *  - text_length: Plaintext length.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_batch_plaintext_set(ujson_t *uj);
-
-/**
- * Fixed vs random data batch encrypt and generate command handler.
- *
- * This command is designed to maximize the capture rate for side-channel
- * attacks. Instead of expecting a plaintext and sending the resulting
- * ciphertext from and to the host for each encryption, this command repeatedly
- * encrypts plaintexts that are generated on the device. The data
- * collection method is based on the derived test requirements (DTR) for TVLA:
- * https://www.rambus.com/wp-content/uploads/2015/08/TVLA-DTR-with-AES.pdf
- * The measurements are taken by using either fixed or randomly selected
- * plaintexts. In order to simplify the analysis, the first encryption has to
- * use fixed plaintext. This minimizes the overhead of UART communication and
- * significantly improves the capture rate. The host must use the same PRNG to
- * be able to compute the random plaintext and the ciphertext of each trace.
- *
- * Packet payload must be a `uint32_t` representation of the number of
- * encryptions to perform. Number of operations of a batch should not be greater
- * than the 'kNumBatchOpsMax' value.
- *
- * Note that the host can partially verify this operation by checking the
- * contents of the 'r' (last ciphertext) packet that is sent at the end of every
- * batch.
- *
- * The uJSON data contains:
- *  - data: The number of encryptions.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_fvsr_data_batch_encrypt(ujson_t *uj);
-
-/**
- * Fixed vs random key batch encrypt and generate command handler.
- *
- * This command is designed to maximize the capture rate for side-channel
- * attacks. Instead of expecting a plaintext and sending the resulting
- * ciphertext from and to the host for each encryption, this command repeatedly
- * encrypts random plaintexts that are generated on the device. The data
- * collection method is based on the derived test requirements (DTR) for TVLA:
- * https://www.rambus.com/wp-content/uploads/2015/08/TVLA-DTR-with-AES.pdf
- * The measurements are taken by using either fixed or randomly selected keys.
- * In order to simplify the analysis, the first encryption has to use fixed key.
- * In addition, a PRNG is used for random key and plaintext generation instead
- * of AES algorithm as specified in the TVLA DTR.
- * This minimizes the overhead of UART communication and significantly improves
- * the capture rate. The host must use the same PRNG to be able to compute the
- * random plaintext, random key and the ciphertext of each trace.
- *
- * Packet payload must be a `uint32_t` representation of the number of
- * encryptions to perform. Number of operations of a batch should not be greater
- * than the 'kNumBatchOpsMax' value.
- *
- * The PRNG should be initialized using the 's' (seed PRNG) command before
- * starting batch encryption. In addition, the fixed key should also be set
- * using 't' (fvsr key set) command before starting batch encryption.
- *
- * Note that the host can partially verify this operation by checking the
- * contents of the 'r' (last ciphertext) packet that is sent at the end of every
- * batch.
- *
- * The uJSON data contains:
- *  - data: The number of encryptions.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_fvsr_key_batch_encrypt(ujson_t *uj);
-
-/**
- * Fixed vs random key batch generate command handler.
- *
- * The uJSON data contains:
- *  - data: The number of encryptions.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_fvsr_key_batch_generate(ujson_t *uj);
-
-/**
- * Fvsr key set command handler.
- *
- * This command is designed to set the fixed key which is used for fvsr key TVLA
- * captures.
- *
- * The key must be `kAesKeyLength` bytes long.
- *
- * The uJSON data contains:
- *  - key: The key to use.
- *  - key_length: The length of the key.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_fvsr_key_set(ujson_t *uj);
-
-/**
- * Set starting values command handler.
- *
- * This function sets starting values for FvsR data generation
- * if the received value is 1.
- * These values are specified in DTR for AES TVLA.
- *
- * The uJSON data contains:
- *  - seed: A buffer holding the seed.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_fvsr_key_start_batch_generate(ujson_t *uj);
-
-/**
- * Initialize AES command handler.
- *
- * This command is designed to setup the AES.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_pentest_init(ujson_t *uj);
-
-/**
- * Key set command handler.
- *
- * This command is designed to set the fixed_key variable and in addition also
- * configures the key into the AES peripheral.
- *
- * The key must be `kAesKeyLength` bytes long.
- *
- * The uJSON data contains:
- *  - key: The key to use.
- *  - key_length: The length of the key.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_sca_key_set(ujson_t *uj);
-
-/**
- * Seed lfsr command handler.
- *
- * This function only supports 4-byte seeds.
- * Enables/disables masking depending on seed value, i.e. 0 for disable.
- *
- * The uJSON data contains:
- *  - seed: A buffer holding the seed.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_pentest_seed_lfsr(ujson_t *uj);
-
-/**
- * Seed lfsr command handler.
- *
- * This function only supports 4-byte seeds.
- * Sets the seed for the LFSR used to determine the order of measurements
- * in fixed-vs-random-data dataset.
- *
- * The uJSON data contains:
- *  - seed: A buffer holding the seed.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
-status_t handle_aes_pentest_seed_lfsr_order(ujson_t *uj);
-
-/**
  * Single encrypt command handler.
  *
  * Encrypts a `kAesTextLength` bytes long plaintext using the AES peripheral and
@@ -293,6 +23,103 @@ status_t handle_aes_pentest_seed_lfsr_order(ujson_t *uj);
  * @return OK or error.
  */
 status_t handle_aes_sca_single_encrypt(ujson_t *uj);
+
+/**
+ * This command is designed to maximize the capture rate for side-channel
+ * attacks. It uses the first supplied plaintext and repeats AES encryptions
+ * by using every ciphertext as next plaintext with a constant key. This
+ * minimizes the overhead of UART communication and significantly improves the
+ * capture rate.
+
+ * Packet payload must be a `uint32_t` representation of the number of
+ * encryptions to perform. Since generated plaintexts are not cached, there is
+ * no limit on the number of encryptions.
+ *
+ * The uJSON data contains:
+ *  - data: The number of encryptions.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_aes_sca_batch_daisy_chain(ujson_t *uj);
+
+/**
+ * Batch random command handler.
+ *
+ * This command is designed to maximize the capture rate for side-channel
+ * attacks. Instead of expecting a plaintext and sending the resulting
+ * ciphertext from and to the host for each encryption, this command repeatedly
+ * encrypts random plaintexts that are generated on the device. This minimizes
+ * the overhead of UART communication and significantly improves the capture
+ * rate. The host must use the same PRNG to be able to compute the plaintext and
+ * the ciphertext of each trace.
+ *
+ * The uJSON data contains:
+ *  - data: The number of encryptions.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_aes_sca_batch_random(ujson_t *uj);
+
+/**
+ * Batch fvsr data command handler.
+ *
+ * This command is designed to maximize the capture rate for side-channel
+ * attacks. This command coins randomness to decide whether to encrypt the given
+ * plaintext or a random one. This minimizes the overhead of UART communication
+ * and significantly improves the capture rate. The host must use the same PRNG
+ * to be able to compute the plaintext and the ciphertext of each trace.
+ *
+ * The uJSON data contains:
+ *  - data: The number of encryptions.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_aes_sca_batch_fvsr_data(ujson_t *uj);
+
+/**
+ * Batch fvsr key command handler.
+ *
+ * This command is designed to maximize the capture rate for side-channel
+ * attacks. This command coins randomness to decide whether to encrypt a random
+ * plaintext with the given key or a random key. This minimizes the overhead of
+ * UART communication and significantly improves the capture rate. The host must
+ * use the same PRNG to be able to compute the plaintext and the ciphertext of
+ * each trace.
+ *
+ * The uJSON data contains:
+ *  - data: The number of encryptions.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_aes_sca_batch_fvsr_key(ujson_t *uj);
+
+/**
+ * Initialize AES command handler.
+ *
+ * This command is designed to setup the AES.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_aes_pentest_init(ujson_t *uj);
+
+/**
+ * Seed lfsr command handler.
+ *
+ * This function only supports 4-byte seeds.
+ * Enables/disables masking depending on seed value, i.e. 0 for disable.
+ *
+ * The uJSON data contains:
+ *  - seed: A buffer holding the seed.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_aes_pentest_seed_lfsr(ujson_t *uj);
 
 /**
  * HMAC SCA command handler.

--- a/sw/device/tests/penetrationtests/json/aes_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/aes_sca_commands.h
@@ -19,20 +19,14 @@ extern "C" {
 // AES SCA arguments
 
 #define AESSCA_SUBCOMMAND(_, value) \
-    value(_, BatchAlternativeEncrypt) \
-    value(_, BatchEncrypt) \
-    value(_, BatchEncryptRandom) \
-    value(_, BatchPlaintextSet) \
-    value(_, FvsrDataBatchEncrypt) \
-    value(_, FvsrKeyBatchEncrypt) \
-    value(_, FvsrKeyBatchGenerate) \
-    value(_, FvsrKeySet) \
-    value(_, FvsrKeyStartBatchGenerate) \
+    value(_, Single) \
+    value(_, BatchDaisy) \
+    value(_, BatchRandom) \
+    value(_, BatchFvsrData) \
+    value(_, BatchFvsrKey) \
     value(_, Init) \
-    value(_, KeySet) \
     value(_, SeedLfsr) \
-    value(_, SeedLfsrOrder) \
-    value(_, SingleEncrypt)
+    value(_, SeedLfsrOrder)
 C_ONLY(UJSON_SERDE_ENUM(AesScaSubcommand, aes_sca_subcommand_t, AESSCA_SUBCOMMAND));
 RUST_ONLY(UJSON_SERDE_ENUM(AesScaSubcommand, aes_sca_subcommand_t, AESSCA_SUBCOMMAND, RUST_DEFAULT_DERIVE, strum::EnumString));
 
@@ -40,10 +34,6 @@ RUST_ONLY(UJSON_SERDE_ENUM(AesScaSubcommand, aes_sca_subcommand_t, AESSCA_SUBCOM
     field(key, uint8_t, AESSCA_CMD_MAX_KEY_BYTES) \
     field(key_length, size_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaKey, aes_sca_key_t, AES_SCA_KEY);
-
-#define AES_SCA_DATA(field, string) \
-    field(data, uint8_t, AESSCA_CMD_MAX_DATA_BYTES)
-UJSON_SERDE_STRUCT(CryptotestAesScaData, aes_sca_data_t, AES_SCA_DATA);
 
 #define AES_SCA_TEXT(field, string) \
     field(text, uint8_t, AESSCA_CMD_MAX_DATA_BYTES) \
@@ -63,13 +53,6 @@ UJSON_SERDE_STRUCT(CryptotestAesScaCiphertext, aes_sca_ciphertext_t, AES_SCA_CIP
     field(fpga_mode, uint8_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaFpgaMode, aes_sca_fpga_mode_t, AES_SCA_FPGA_MODE);
 
-#define AES_SCA_CMD(field, string) \
-    field(cmd, uint32_t)
-UJSON_SERDE_STRUCT(CryptotestAesScaCmd, aes_sca_cmd_t, AES_SCA_CMD);
-
-#define AES_SCA_EMPTY(field, string) \
-    field(success, bool)
-UJSON_SERDE_STRUCT(CryptotestAesScaEmpty, aes_sca_empty_t, AES_SCA_EMPTY);
 // clang-format on
 
 #ifdef __cplusplus

--- a/sw/host/penetrationtests/testvectors/data/sca_aes.json
+++ b/sw/host/penetrationtests/testvectors/data/sca_aes.json
@@ -19,56 +19,39 @@
   },
   {
     "test_case_id": 3,
-    "command": "KeySet",
-    "input": "{\"key\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"key_length\":16}"
-  },
-  {
-    "test_case_id": 4,
-    "command": "SingleEncrypt",
+    "command": "Single",
+    "key": "{\"key\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"key_length\":16}",
     "input": "{\"text\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"text_length\":16}",
     "expected_output": ["{\"ciphertext\": [10,148,11,181,65,110,240,69,241,195,148,88,198,83,234,90],\"ciphertext_length\":16}"]
   },
   {
+    "test_case_id": 4,
+    "command": "BatchDaisy",
+    "key": "{\"key\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"key_length\":16}",
+    "message": "{\"text\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"text_length\":16}",
+    "input": "{\"num_enc\":1}",
+    "expected_output": ["{\"ciphertext\": [10,148,11,181,65,110,240,69,241,195,148,88,198,83,234,90],\"ciphertext_length\":16}"]
+  },
+  {
     "test_case_id": 5,
-    "command": "KeySet",
-    "input": "{\"key\":[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0],\"key_length\":16}"
+    "command": "BatchRandom",
+    "key": "{\"key\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"key_length\":16}",
+    "input": "{\"num_enc\":5}",
+    "expected_output": ["{\"ciphertext\": [43,124,136,98,79,239,79,213,254,243,234,57,24,36,150,230],\"ciphertext_length\":16}"]
   },
   {
     "test_case_id": 6,
-    "command": "BatchPlaintextSet",
-    "input": "{\"text\":[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0],\"text_length\":16}"
+    "command": "BatchFvsrData",
+    "key": "{\"key\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"key_length\":16}",
+    "message": "{\"text\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"text_length\":16}",
+    "input": "{\"num_enc\":10}",
+    "expected_output": ["{\"ciphertext\": [11,220,94,112,90,30,79,78,132,107,225,207,60,76,164,92],\"ciphertext_length\":16}"]
   },
   {
     "test_case_id": 7,
-    "command": "BatchAlternativeEncrypt",
-    "input": "{\"num_enc\":1}",
-    "expected_output": ["{\"ciphertext\": [197,204,143,194,239,52,93,146,171,137,123,242,255,157,224,249],\"ciphertext_length\":16}"]
-  },
-  {
-    "test_case_id": 8,
-    "command": "FvsrKeyStartBatchGenerate",
-    "input": "{\"cmd\":1}"
-  },
-  {
-    "test_case_id": 9,
-    "command": "FvsrKeyBatchGenerate",
-    "input": "{\"num_enc\":5}"
-  },
-  {
-    "test_case_id": 10,
-    "command": "FvsrKeyBatchEncrypt",
-    "input": "{\"num_enc\":5}",
-    "expected_output": ["{\"ciphertext\": [120,56,194,222,9,241,121,100,181,134,174,38,13,234,193,178],\"ciphertext_length\":16}"]
-  },
-  {
-    "test_case_id": 11,
-    "command": "FvsrKeyStartBatchGenerate",
-    "input": "{\"cmd\":2}"
-  },
-  {
-    "test_case_id": 12,
-    "command": "FvsrDataBatchEncrypt",
+    "command": "BatchFvsrKey",
+    "key": "{\"key\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],\"key_length\":16}",
     "input": "{\"num_enc\":10}",
-    "expected_output": ["{\"ciphertext\": [17,48,185,104,21,63,1,238,7,83,64,189,59,94,162,240],\"ciphertext_length\":16}"]
+    "expected_output": ["{\"ciphertext\": [16,100,21,248,236,192,48,45,173,59,69,111,175,194,18,52],\"ciphertext_length\":16}"]
   }
 ]

--- a/sw/host/tests/penetrationtests/sca_aes/src/main.rs
+++ b/sw/host/tests/penetrationtests/sca_aes/src/main.rs
@@ -43,6 +43,10 @@ struct ScaAesTestCase {
     #[serde(default)]
     input: String,
     #[serde(default)]
+    message: String,
+    #[serde(default)]
+    key: String,
+    #[serde(default)]
     sensors: String,
     #[serde(default)]
     expected_output: Vec<String>,
@@ -73,6 +77,16 @@ fn run_sca_aes_testcase(
     }
 
     // Check if we need to send an input.
+    if !test_case.key.is_empty() {
+        let key: serde_json::Value = serde_json::from_str(test_case.key.as_str()).unwrap();
+        key.send(uart)?;
+    }
+
+    if !test_case.message.is_empty() {
+        let message: serde_json::Value = serde_json::from_str(test_case.message.as_str()).unwrap();
+        message.send(uart)?;
+    }
+
     if !test_case.input.is_empty() {
         let input: serde_json::Value = serde_json::from_str(test_case.input.as_str()).unwrap();
         input.send(uart)?;


### PR DESCRIPTION
Make the aes sca pentest code up-to-date and conform to other tests such as hmac sca. Make it include the option for a single encryption, a random batch, a data fvsr, a key fvsr, and a daisy chain test.