### PR TITLE
[crypto] CTRL regs hardening: AES

### DIFF
--- a/sw/device/lib/crypto/drivers/aes.c
+++ b/sw/device/lib/crypto/drivers/aes.c
@@ -88,6 +88,159 @@ static status_t aes_write_key(aes_key_t key) {
 }
 
 /**
+ * Compute the ctrl register value for the given parameters.
+ *
+ * @param key AES key.
+ * @param encrypt True for encryption, false for decryption.
+ * @return result, OK or error.
+ */
+static status_t compute_ctrl_reg(aes_key_t key, hardened_bool_t encrypt,
+                                 uint32_t *ctrl_reg) {
+  *ctrl_reg = AES_CTRL_SHADOWED_REG_RESVAL;
+
+  // Set the operation (encrypt or decrypt).
+  hardened_bool_t operation_enc = launder32(0);
+  switch (encrypt) {
+    case kHardenedBoolTrue:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_OPERATION_FIELD,
+                                 AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC);
+      operation_enc = launder32(operation_enc) | kHardenedBoolTrue;
+      break;
+    case kHardenedBoolFalse:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_OPERATION_FIELD,
+                                 AES_CTRL_SHADOWED_OPERATION_VALUE_AES_DEC);
+      operation_enc = launder32(operation_enc) | kHardenedBoolFalse;
+      break;
+    default:
+      // Invalid value.
+      return OTCRYPTO_BAD_ARGS;
+  }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(operation_enc), encrypt);
+
+  // Indicate whether the key will be sideloaded.
+  hardened_bool_t which_sideload = launder32(0);
+  switch (key.sideload) {
+    case kHardenedBoolTrue:
+      *ctrl_reg =
+          bitfield_bit32_write(*ctrl_reg, AES_CTRL_SHADOWED_SIDELOAD_BIT, true);
+      which_sideload = launder32(which_sideload) | kHardenedBoolTrue;
+      break;
+    case kHardenedBoolFalse:
+      *ctrl_reg = bitfield_bit32_write(*ctrl_reg,
+                                       AES_CTRL_SHADOWED_SIDELOAD_BIT, false);
+      which_sideload = launder32(which_sideload) | kHardenedBoolFalse;
+      break;
+    default:
+      // Invalid value.
+      return OTCRYPTO_BAD_ARGS;
+  }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(which_sideload), key.sideload);
+
+  // Translate the cipher mode to the hardware-encoding value and write the
+  // control reg field.
+  aes_cipher_mode_t mode_written = launder32(0);
+  switch (launder32(key.mode)) {
+    case kAesCipherModeEcb:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB);
+      mode_written = launder32(mode_written) | kAesCipherModeEcb;
+      break;
+    case kAesCipherModeCbc:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_CBC);
+      mode_written = launder32(mode_written) | kAesCipherModeCbc;
+      break;
+    case kAesCipherModeCfb:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_CFB);
+      mode_written = launder32(mode_written) | kAesCipherModeCfb;
+      break;
+    case kAesCipherModeOfb:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_OFB);
+      mode_written = launder32(mode_written) | kAesCipherModeOfb;
+      break;
+    case kAesCipherModeCtr:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                                 AES_CTRL_SHADOWED_MODE_VALUE_AES_CTR);
+      mode_written = launder32(mode_written) | kAesCipherModeCtr;
+      break;
+    default:
+      // Invalid value.
+      return OTCRYPTO_BAD_ARGS;
+  }
+  // Check if we landed in the correct case statement. Use ORs for this to
+  // avoid that multiple cases were executed.
+  HARDENED_CHECK_EQ(launder32(mode_written), key.mode);
+
+  // Translate the key length to the hardware-encoding value and write the
+  // control reg field.
+  size_t key_len_written;
+  switch (key.key_len) {
+    case kAesKeyWordLen128:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
+                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128);
+      key_len_written = launder32(kAesKeyWordLen128);
+      break;
+    case kAesKeyWordLen192:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
+                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_192);
+      key_len_written = launder32(kAesKeyWordLen192);
+      break;
+    case kAesKeyWordLen256:
+      *ctrl_reg =
+          bitfield_field32_write(*ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
+                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_256);
+      key_len_written = launder32(kAesKeyWordLen256);
+      break;
+    default:
+      // Invalid value.
+      return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(key_len_written, key.key_len);
+
+  // Never enable manual operation.
+  *ctrl_reg = bitfield_bit32_write(
+      *ctrl_reg, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false);
+
+  // Always set the PRNG reseed rate to once per 64 blocks.
+  *ctrl_reg = bitfield_field32_write(
+      *ctrl_reg, AES_CTRL_SHADOWED_PRNG_RESEED_RATE_FIELD,
+      AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_64);
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Verify the ctrl register value for the given parameters.
+ *
+ * @param key AES key.
+ * @param encrypt True for encryption, false for decryption.
+ * @return result, OK or error.
+ */
+status_t aes_verify_ctrl_reg(aes_key_t key, hardened_bool_t encrypt) {
+  uint32_t ctrl_reg;
+
+  HARDENED_TRY(compute_ctrl_reg(key, encrypt, &ctrl_reg));
+  HARDENED_CHECK_EQ(abs_mmio_read32(aes_base() + AES_CTRL_SHADOWED_REG_OFFSET),
+                    launder32(ctrl_reg));
+
+  return OTCRYPTO_OK;
+}
+
+/**
  * Configure the AES block and write the key and IV if applicable.
  *
  * @param key AES key.
@@ -104,125 +257,9 @@ static status_t aes_begin(aes_key_t key, const aes_block_t *iv,
   // Wait for the AES block to be idle.
   HARDENED_TRY(spin_until(AES_STATUS_IDLE_BIT));
 
-  uint32_t ctrl_reg = AES_CTRL_SHADOWED_REG_RESVAL;
+  uint32_t ctrl_reg;
 
-  // Set the operation (encrypt or decrypt).
-  hardened_bool_t operation_enc = launder32(0);
-  switch (encrypt) {
-    case kHardenedBoolTrue:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_OPERATION_FIELD,
-                                 AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC);
-      operation_enc = launder32(operation_enc) | kHardenedBoolTrue;
-      break;
-    case kHardenedBoolFalse:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_OPERATION_FIELD,
-                                 AES_CTRL_SHADOWED_OPERATION_VALUE_AES_DEC);
-      operation_enc = launder32(operation_enc) | kHardenedBoolFalse;
-      break;
-    default:
-      // Invalid value.
-      return OTCRYPTO_BAD_ARGS;
-  }
-  // Check if we landed in the correct case statement. Use ORs for this to
-  // avoid that multiple cases were executed.
-  HARDENED_CHECK_EQ(launder32(operation_enc), encrypt);
-
-  // Indicate whether the key will be sideloaded.
-  hardened_bool_t which_sideload = launder32(0);
-  switch (key.sideload) {
-    case kHardenedBoolTrue:
-      ctrl_reg =
-          bitfield_bit32_write(ctrl_reg, AES_CTRL_SHADOWED_SIDELOAD_BIT, true);
-      which_sideload = launder32(which_sideload) | kHardenedBoolTrue;
-      break;
-    case kHardenedBoolFalse:
-      ctrl_reg =
-          bitfield_bit32_write(ctrl_reg, AES_CTRL_SHADOWED_SIDELOAD_BIT, false);
-      which_sideload = launder32(which_sideload) | kHardenedBoolFalse;
-      break;
-    default:
-      // Invalid value.
-      return OTCRYPTO_BAD_ARGS;
-  }
-  // Check if we landed in the correct case statement. Use ORs for this to
-  // avoid that multiple cases were executed.
-  HARDENED_CHECK_EQ(launder32(which_sideload), key.sideload);
-
-  // Translate the cipher mode to the hardware-encoding value and write the
-  // control reg field.
-  aes_cipher_mode_t mode_written = launder32(0);
-  switch (launder32(key.mode)) {
-    case kAesCipherModeEcb:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB);
-      mode_written = launder32(mode_written) | kAesCipherModeEcb;
-      break;
-    case kAesCipherModeCbc:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_CBC);
-      mode_written = launder32(mode_written) | kAesCipherModeCbc;
-      break;
-    case kAesCipherModeCfb:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_CFB);
-      mode_written = launder32(mode_written) | kAesCipherModeCfb;
-      break;
-    case kAesCipherModeOfb:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_OFB);
-      mode_written = launder32(mode_written) | kAesCipherModeOfb;
-      break;
-    case kAesCipherModeCtr:
-      ctrl_reg = bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_MODE_FIELD,
-                                        AES_CTRL_SHADOWED_MODE_VALUE_AES_CTR);
-      mode_written = launder32(mode_written) | kAesCipherModeCtr;
-      break;
-    default:
-      // Invalid value.
-      return OTCRYPTO_BAD_ARGS;
-  }
-  // Check if we landed in the correct case statement. Use ORs for this to
-  // avoid that multiple cases were executed.
-  HARDENED_CHECK_EQ(launder32(mode_written), key.mode);
-
-  // Translate the key length to the hardware-encoding value and write the
-  // control reg field.
-  size_t key_len_written;
-  switch (key.key_len) {
-    case kAesKeyWordLen128:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
-                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128);
-      key_len_written = launder32(kAesKeyWordLen128);
-      break;
-    case kAesKeyWordLen192:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
-                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_192);
-      key_len_written = launder32(kAesKeyWordLen192);
-      break;
-    case kAesKeyWordLen256:
-      ctrl_reg =
-          bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
-                                 AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_256);
-      key_len_written = launder32(kAesKeyWordLen256);
-      break;
-    default:
-      // Invalid value.
-      return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(key_len_written, key.key_len);
-
-  // Never enable manual operation.
-  ctrl_reg = bitfield_bit32_write(
-      ctrl_reg, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false);
-
-  // Always set the PRNG reseed rate to once per 64 blocks.
-  ctrl_reg =
-      bitfield_field32_write(ctrl_reg, AES_CTRL_SHADOWED_PRNG_RESEED_RATE_FIELD,
-                             AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_64);
+  HARDENED_TRY(compute_ctrl_reg(key, encrypt, &ctrl_reg));
 
   abs_mmio_write32_shadowed(aes_base() + AES_CTRL_SHADOWED_REG_OFFSET,
                             ctrl_reg);

--- a/sw/device/lib/crypto/drivers/aes.h
+++ b/sw/device/lib/crypto/drivers/aes.h
@@ -81,6 +81,15 @@ typedef struct aes_key {
 } aes_key_t;
 
 /**
+ * Verify the ctrl register value for the given parameters.
+ *
+ * @param key AES key.
+ * @param encrypt True for encryption, false for decryption.
+ * @return result, OK or error.
+ */
+status_t aes_verify_ctrl_reg(aes_key_t key, hardened_bool_t encrypt);
+
+/**
  * Prepares the AES hardware to perform an encryption operation.
  *
  * If `key.sideload` is true, then this routine does not load the key; the

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -425,6 +425,15 @@ static otcrypto_status_t otcrypto_aes_impl(
   // Check that the loop ran for the correct number of iterations.
   HARDENED_CHECK_EQ(launder32(i), 0);
 
+  // Verify the CTRL register again.
+
+  // Since this is a checking mechanism itself, we do not add extra redundancy
+  // to the if loop.
+  hardened_bool_t encrypt = kHardenedBoolTrue;
+  if (aes_operation == kOtcryptoAesOperationDecrypt)
+    encrypt = kHardenedBoolFalse;
+  HARDENED_TRY(aes_verify_ctrl_reg(aes_key, encrypt));
+
   // Deinitialize the AES block and update the IV (in ECB mode, skip the IV).
   if (aes_mode == kAesCipherModeEcb) {
     HARDENED_TRY(aes_end(NULL));


### PR DESCRIPTION
Reread the CTRL register from the AES once it is done with its operation. This is to stop potential fault attacks on the security critical registers.